### PR TITLE
Fix conversation screen isn't opening on iOS

### DIFF
--- a/ios/ZendeskMessagingModule.swift
+++ b/ios/ZendeskMessagingModule.swift
@@ -124,9 +124,14 @@ public class ZendeskMessagingModule: Module {
         return
       }
       
-      rootController.present(viewController, animated: true) {
-        resolve("Messaging view opened successfully")
+      if let nav = rootController.navigationController {
+        nav.pushViewController(viewController, animated: true)
+      } else {
+        let nav = UINavigationController(rootViewController: viewController)
+        rootController.present(nav, animated: true, completion: nil)
       }
+      
+      resolve("Messaging view opened successfully")
     }
   }
   


### PR DESCRIPTION
This PR modifies the view controller presentation logic to ensure the view is pushed onto the navigation stack or presented within a navigation controller if one does not exist.